### PR TITLE
Updating extrinsic calibration and adding in Subbu's lidar-camera slider gui

### DIFF
--- a/autovalet_description/urdf/autovalet.urdf.xacro
+++ b/autovalet_description/urdf/autovalet.urdf.xacro
@@ -1,24 +1,24 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="autovalet_husky">
 
-	<!-- Include the link for the realsense sensors from the local realsense2_package--> 
+	<!-- Include the link for the realsense sensors from the local realsense2_package-->
 	<xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
 	<!-- Include the velodyne model from the velodyne description package-->
 	<xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro"/>
-  		
-	<!-- Define the front camera link -->
-	<sensor_d435 parent="velodyne" name="backCamera" >
-	    <origin xyz="0 -0.11 -0.59" rpy="0 0 -1.57079" />
+
+	<sensor_d435 parent="front_bumper_link" name="frontCamera" >
+	    <origin xyz="-0.305 0.02 0.91" rpy="0 0 0" />
 	</sensor_d435>
 
-	<!-- Define the back camera link -->
-	<sensor_d435 parent="velodyne" name="frontCamera" >
-	    <origin xyz="0 0.197 -0.59" rpy="0 0 1.57079"/>
+	<!-- Define the back camera link to the front camera-->
+	<sensor_d435 parent="frontCamera_bottom_screw_frame" name="backCamera" >
+	    <origin xyz="-0.235 0 0" rpy="0 0 3.14159"/>
 	</sensor_d435>
 
-	<!-- Define the velodyne link to the husky (base_link)-->
-	<VLP-16 parent="base_footprint" name="velodyne" topic="/velodyne_points" hz="10" samples="440">
-    	<origin xyz="0 -0.015 1.47" rpy="0 0 -1.570796326"/> 
+	<!-- Define the velodyne link to the front camera-->
+	<VLP-16 parent="frontCamera_bottom_screw_frame" name="velodyne" topic="/velodyne_points" hz="10" samples="440">
+        <!-- the z coordinate is wrong. in our sensor frame, it's more like .35m. but .22m aligns the point clouds in rviz...-->
+    	<origin xyz="-0.155 0.0 0.22" rpy="0.0 0.0 0.0"/>
   	</VLP-16>
 
 </robot>

--- a/autovalet_husky/CMakeLists.txt
+++ b/autovalet_husky/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
   std_msgs
+  dynamic_reconfigure
 )
 
 ## System dependencies are found with CMake's conventions
@@ -88,10 +89,10 @@ find_package(catkin REQUIRED COMPONENTS
 ##     and list every .cfg file to be processed
 
 ## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
+generate_dynamic_reconfigure_options(
+  config/lidar_camera_tf.cfg
 #   cfg/DynReconf2.cfg
-# )
+)
 
 ###################################
 ## catkin specific configuration ##

--- a/autovalet_husky/config/lidar_camera_tf.cfg
+++ b/autovalet_husky/config/lidar_camera_tf.cfg
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# This configuration file is for the rqt panel that is used in
+# dynamic reconfigure.
+
+# author: subramak@andrew.cmu.edu
+# Date  : 4 Sep 2020
+
+# Changelog:
+# 	subbu - 09/04 - Initial commit
+
+
+PACKAGE = "autovalet_husky"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+# Actual TF params:
+gen.add("x_pos", double_t, 0, "X_Position",    0, -1,   1)		# defaults to 0 and ranges from -1 to 1
+gen.add("y_pos", double_t, 0, "Y_Position",    0, -1,   1) 	    # default 0 and ranges from -1 to 1
+gen.add("z_pos", double_t, 0, "Z_Position",    0, -1,   1)		# default 0 and ranges from -1 to 1
+
+
+gen.add("yaw", double_t, 0, "Yaw",    0, -3.14,   3.14)			# default 0 and ranges from -2*pi to +2*pi
+gen.add("pitch", double_t, 0, "Pitch",    0, -3.14,   3.14)		# default 0 and ranges from -2*pi to +2*pi
+gen.add("roll", double_t, 0, "Roll",    0, -3.14,   3.14)		# default 0 and ranges from -2*pi to +2*pi
+
+exit(gen.generate(PACKAGE, "vlp_cam_calib", "lidar_camera_tf"))

--- a/autovalet_husky/launch/integrated_sensor.launch
+++ b/autovalet_husky/launch/integrated_sensor.launch
@@ -4,28 +4,35 @@
     <remap from="odometry/filtered" to="my_odom"/>
     <!-- Husky setup and teleop -->
 	<include file="$(find autovalet_husky)/launch/valet_bringup.launch" />
-	
-	<!-- <arg name="cam_1_serial_number" value="819112073090" /> -->
-	<arg name="cam_2_serial_number" value="909512071908" />
-	
+
+	<arg name="cam_1_serial_number" value="909512071908" />
+	<arg name="cam_2_serial_number" value="819112073090" />
+
 	<!-- IntelRealsense launching -->
-<!--   	<include file="$(find realsense2_camera)/launch/rs_camera.launch">
+  	<include file="$(find realsense2_camera)/launch/rs_camera.launch">
     	<arg name="camera" value="backCamera"/>
     	<arg name="serial_no" value="$(arg cam_1_serial_number)"/>
     	<arg name="filters" value="pointcloud"/>
-  	</include> -->
+  	</include>
 
   	<include file="$(find realsense2_camera)/launch/rs_camera.launch">
     	<arg name="camera" value="frontCamera"/>
     	<arg name="serial_no" value="$(arg cam_2_serial_number)"/>
     	<arg name="filters" value="pointcloud"/>
         <arg name="unite_imu_method" value="linear_interpolation"/>
+        <arg name="color_width"         default="1920"/>
+        <arg name="color_height"        default="1080"/>
+        <arg name="depth_width"         default="848"/>
+        <arg name="depth_height"        default="480"/>
+        
+        <arg name="enable_fisheye"      default="false"/>
+        <arg name="enable_infra1"       default="false"/>
+        <arg name="enable_infra2"       default="false"/>
+
 	 </include>
 
 	<!-- Velodyne launching -->
-    <!-- <include file="$(find velodyne_pointcloud)/launch/VLP16_points.launch" /> -->
-
-    <!-- odom remap for rtab -->
+    <include file="$(find velodyne_pointcloud)/launch/VLP16_points.launch" />
 
     <!-- RVIZ -->
     <node type="rviz" name="rviz" pkg="rviz" args="-d $(find autovalet_husky)/rviz/config.rviz" />

--- a/autovalet_husky/scripts/vlp_cam_calib.py
+++ b/autovalet_husky/scripts/vlp_cam_calib.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+"""
+tf2 broadcaster node
+This node broadcasts couple of tf2 frames and ensures these frames can
+be updated using a dynamic reconfigure server. Primarily intended to find
+tf between velodyne and d435 in the AutoValet project.
+
+Usage: rosrun autovalet_husky vlp_cam_calib.py <parent_frame> <child_frame>
+Run Rviz to visualize the tf moving around. Overwrite XYZ-RPY when clouds align.
+
+author: subramak@andrew.cmu.edu
+Date  : 4 Sep 2020
+
+Changelog:
+    subbu - 09/04 - Initial commit
+
+"""
+
+# references:
+# 1. https://github.com/azhar92/scooter-mode
+# 2. https://answers.ros.org/question/333820/use-tf2-within-a-dynamic-reconfigure-server/
+
+## Import standard library packages ##
+import sys
+
+## Import ros packages ##
+import rospy
+from dynamic_reconfigure.server import Server
+from autovalet_husky.cfg import lidar_camera_tfConfig
+import tf_conversions
+import tf
+import tf2_ros
+import geometry_msgs.msg
+
+#################################################
+## tf2_broadcaster class ########################
+#################################################
+class tf2_broadcaster():
+    def __init__(self, parent_frame="velodyne", child_id="backCamera_link"):
+        """Calib_frame_tf2_broadcaster class initialization.
+
+        Parameters
+        ----------
+        parent_frame : str, optional
+            Name of the parent frame, by default "panda_link0"
+        child_id : str, optional
+            Name of the child frame, by default "calib_frame"
+        """
+
+        ## Retrieve parameters ##
+        self.parent_frame = parent_frame
+        self.child_id = child_id
+
+        ## Create static broadcster ##
+        self.static_br = tf2_ros.StaticTransformBroadcaster()
+
+        ## Initialize transform broardcaster ##
+        self.timer = rospy.Timer(rospy.Duration(1.0/10.0),
+                                 self.tf2_broadcaster_callback)
+        self.br = tf2_ros.TransformBroadcaster()
+        self.tf_msg = geometry_msgs.msg.TransformStamped()
+
+        ## Initialize dynamic reconfigure server ##
+        self.srv = Server(lidar_camera_tfConfig, self.dync_reconf_callback)
+
+    def dync_reconf_callback(self, config, level):
+        """Dynamic reconfigure callback function.
+
+        Parameters
+        ----------
+        config : dict
+            Dictionary containing the dynamically reconfigured parameters.
+        level : int
+            A bitmask which will later be passed to the dynamic reconfigure callback.
+            When the callback is called all of the level values for parameters that have
+            been changed are ORed together and the resulting value is passed to the callback.
+        """
+
+        ## Print information ##
+        rospy.loginfo("""Reconfigure Request: {x_pos}, {y_pos},\
+            , {z_pos}, {yaw}, {pitch} & {roll}""".format(**config))
+
+        ## Read dynamic parameter values ##
+        self.x_pos = config["x_pos"]
+        self.y_pos = config["y_pos"]
+        self.z_pos = config["z_pos"]
+        self.yaw = config["yaw"]
+        self.pitch = config["pitch"]
+        self.roll = config["roll"]
+
+        quat = tf.transformations.quaternion_from_euler(
+            float(self.yaw), float(self.pitch), float(self.roll), axes='rzyx')
+        print(quat)
+
+        ## Update parameters in the parameter server ##
+        rospy.set_param('x_pos', config["x_pos"])
+        rospy.set_param('y_pos', config["y_pos"])
+        rospy.set_param('z_pos', config["z_pos"])
+        rospy.set_param('yaw', config["yaw"])
+        rospy.set_param('pitch', config["pitch"])
+        rospy.set_param('roll', config["roll"])
+
+        ## Return possibly updated configuration ##
+        return config
+
+    def tf2_broadcaster_callback(self, event=None):
+        """TF2 broadcaster callback function. This function broadcast the tf2 frames.
+
+        Parameters
+        ----------
+        event : rospy.timer.TimerEvent, optional
+            Structure passed in provides you timing information that can be useful when debugging or profiling. , by default None
+        """
+        ## Generate TF message ##
+        self.tf_msg.header.stamp = rospy.Time.now()
+        self.tf_msg.header.frame_id = self.parent_frame
+        self.tf_msg.child_frame_id = self.child_id
+        self.tf_msg.transform.translation.x = self.x_pos
+        self.tf_msg.transform.translation.y = self.y_pos
+        self.tf_msg.transform.translation.z = self.z_pos
+        quat = tf.transformations.quaternion_from_euler(
+            float(self.yaw), float(self.pitch), float(self.roll), axes='rzyx')
+        self.tf_msg.transform.rotation.x = quat[0]
+        self.tf_msg.transform.rotation.y = quat[1]
+        self.tf_msg.transform.rotation.z = quat[2]
+        self.tf_msg.transform.rotation.w = quat[3]
+
+        ## Send tf message ##
+        self.br.sendTransform(self.tf_msg)
+
+#################################################
+## Main script ##################################
+#################################################
+if __name__ == "__main__":
+
+    ## Initialize TF2 broadcaster node ##
+    rospy.init_node('Lidar_TF_tester', anonymous=False)
+
+    ## Check if enough arguments are supplied ##
+    if len(sys.argv) < 3:
+        rospy.logerr('Invalid number of parameters\nusage: '
+                     './static_calib_frame_tf2_broadcaster.py '
+                     'frame_id child_frame_name')
+        sys.exit(0)
+    else:
+
+        ## Check if frame name is valid ##
+        if sys.argv[2] == 'world':
+            rospy.logerr('Your frame cannot be named "world"')
+            sys.exit(0)
+
+    ## Initialize calib frame broadcaster ##
+    tf2_broadcaster(sys.argv[1], sys.argv[2])
+
+    ## Spin forever ##
+    rospy.spin()

--- a/autovalet_realsense/realsense2_camera/launch/rs_camera.launch
+++ b/autovalet_realsense/realsense2_camera/launch/rs_camera.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
   <arg name="serial_no"           default=""/>
   <arg name="usb_port_id"         default=""/>


### PR DESCRIPTION
This reflects the current calibration between lidar and camera. The depth is aligned well but the height of the lidar wrt camera needed to be 22 cm (actual measured distance is ~35cm) in order for point clouds to align. We want to test this out, but it could still work well enough moving forward since we never use the physical transform btwn camera and lidar.

Notes:
This added some gui stuff that Subbu wrote. In order for it to compile, you need to do this:

```
chmod +x ~/catkin_autovalet/src/autovalet/autovalet_husky/config/lidar_camera_tf.cfg
chmod +x ~/catkin_autovalet/src/autovalet/autovalet_husky/scripts/vlp_cam_calib.py
```

